### PR TITLE
shared_example for creating object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "simplecov-rcov"
 gem "sinatra", github: "sinatra/sinatra"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem 'whenever', require: false
+gem "whenever", require: false
 
 group :development do
   gem "bullet"

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -6,24 +6,17 @@ describe AccountsController, type: :controller do
 
   before{@request.env["devise.mapping"] = Devise.mappings[:account]}
 
-  describe "GET #new" do
-    it "should render the :new view" do
-      get :new
-      expect(response).to render_template :new
-    end
-  end
+  it_behaves_like "render :new view"
 
   describe "POST #create" do
-    let!(:account_count){Account.count}
+    let!(:count_before){Account.count}
 
     context "when params is valid" do
       before do
         post :create, params: account_params
       end
 
-      it "increase number of account by 1" do
-        expect(Account.count).to eq(account_count + 1)
-      end
+      it_behaves_like "create a new object successfully", Account
 
       it "redirect to root_path" do
         expect(response).to redirect_to root_path
@@ -36,9 +29,7 @@ describe AccountsController, type: :controller do
         post :create, params: account_params
       end
 
-      it "don't change number of account" do
-        expect(Account.count).to eq(account_count)
-      end
+      it_behaves_like "create a new object failed", Account
 
       it "redirect to new_user_path" do
         expect(response).to render_template :new

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -13,15 +13,10 @@ describe CompaniesController, type: :controller do
 
   before{sign_in account_company}
 
-  describe "GET #new" do
-    it "should render the :new view" do
-      get :new
-      expect(response).to render_template :new
-    end
-  end
+  it_behaves_like "render :new view"
 
   describe "POST #create" do
-    let!(:company_count){Company.count}
+    let!(:count_before){Company.count}
     before do
       sign_out account_company
       sign_in account_company2
@@ -38,9 +33,7 @@ describe CompaniesController, type: :controller do
         expect(response).to redirect_to root_path
       end
 
-      it "should up number of companies to 1" do
-        expect(Company.count).to eq(company_count + 1)
-      end
+      it_behaves_like "create a new object successfully", Company
     end
 
     context "when company information is invalid" do
@@ -57,9 +50,7 @@ describe CompaniesController, type: :controller do
         expect(assigns(:company).errors.messages[:name]).to be_present
       end
 
-      it "should not change number of companies" do
-        expect(Company.count).to eq(company_count)
-      end
+      it_behaves_like "create a new object failed", Company
     end
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -5,13 +5,7 @@ RSpec.describe SessionsController, type: :controller do
 
   before{@request.env["devise.mapping"] = Devise.mappings[:account]}
 
-  describe "GET /new" do
-    before {get :new}
-
-    it "render template :new" do
-      expect(response).to render_template :new
-    end
-  end
+  it_behaves_like "render :new view"
 
   describe "POST /create" do
     context "when login with correct params" do

--- a/spec/controllers/user_apply_jobs_controller_spec.rb
+++ b/spec/controllers/user_apply_jobs_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe UserApplyJobsController, type: :controller do
   end
 
   describe "POST /create" do
-    let!(:user_apply_job_count){UserApplyJob.count}
+    let!(:count_before){UserApplyJob.count}
 
     before {sign_in account_1}
 
@@ -58,9 +58,7 @@ RSpec.describe UserApplyJobsController, type: :controller do
         post :create, params: params
       end
 
-      it "increase number of user_apply_job by 1" do
-        expect(UserApplyJob.count).to eq(user_apply_job_count + 1)
-      end
+      it_behaves_like "create a new object successfully", UserApplyJob
 
       it "redirect to user_path" do
         expect(response).to redirect_to account_1.user
@@ -73,9 +71,7 @@ RSpec.describe UserApplyJobsController, type: :controller do
         post :create, params: params
       end
 
-      it "don't change number of user_apply_job" do
-        expect(UserApplyJob.count).to eq(user_apply_job_count)
-      end
+      it_behaves_like "create a new object failed", UserApplyJob
     end
   end
 end

--- a/spec/support/shared_examples/create_object_examples.rb
+++ b/spec/support/shared_examples/create_object_examples.rb
@@ -1,0 +1,11 @@
+RSpec.shared_examples "create a new object successfully" do |obj|
+  it "increase the number of #{obj.name} by 1" do
+    expect(obj.count).to eq(count_before + 1)
+  end
+end
+
+RSpec.shared_examples "create a new object failed" do |obj|
+  it "don't change the number of #{obj.name}" do
+    expect(obj.count).to eq(count_before)
+  end
+end

--- a/spec/support/shared_examples/get_new_examples.rb
+++ b/spec/support/shared_examples/get_new_examples.rb
@@ -1,0 +1,8 @@
+RSpec.shared_examples "render :new view" do
+  describe "GET #new" do
+    it "should render the :new view" do
+      get :new
+      expect(response).to render_template :new
+    end
+  end
+end


### PR DESCRIPTION
## WHAT (optional)
- Áp dụng shared_example vào rspec.

## HOW
- Tạo file spec/support/shared_examples/create_object_examples.rb và tạo 2 examples cho 2 trường hợp create object thành công và thất bại.
- Thay thế các test unit kiểm tra số lượng bản ghi sau khi create object bằng shared_example.
- Tạo file spec/support/shared_examples/get_new_examples.rb và tạo example cho method get #new.

